### PR TITLE
(MTV Music Generator 2) Trim spacing from folder and filenames after using String VAR P VAR

### DIFF
--- a/QuickBMS/PS2/MTV_Music_Generator_2_(PS2)_WAD.bms
+++ b/QuickBMS/PS2/MTV_Music_Generator_2_(PS2)_WAD.bms
@@ -39,10 +39,12 @@ For A = 0 < COUNT1
 			GetArray TEMP2 1 PARENT_ID					# parent idx for this folder
 
 			String FNAME P "%TEMPNAME%\%FNAME%"
+			String FNAME _ FNAME
 			Math PARENT_ID = TEMP2
 		Next B
 
 		String FILENAME P "%FNAME%%NAME%"
+		String FILENAME _ FILENAME
 
 		XMath ENTRY2 "TABLE2 + (ID * 8) - 8"					# 1-based file index values
 		Goto ENTRY2


### PR DESCRIPTION
It turns out that for some unintentional reason, newlines were being created in the middle of the variables, resulting in loss of the filename as a side effect. By trimming away spacing, the newline characters will no longer interfere with the filename detection process.

Fun fact: The script also works on Digital Hitz Factory, provided that the filename used is not "WAD", but rather "DATA" (thus a minor modification to the script is required for filename reasons, but other than that it works).